### PR TITLE
fix problem when working with tbl_df objects data.frames from popular…

### DIFF
--- a/R/terms-expand.R
+++ b/R/terms-expand.R
@@ -31,7 +31,7 @@ expandData <- function (x, data, nMed, ...)
     if (inherits(data, "environment")) data <- as.data.frame(as.list(data))
     args[[1]] <- if (!is.null(args$vartype) && grepl("factor", 
         attr(eval(args$vartype), "xasis"))) {
-        quote(as.factor(data[, x]))
+        quote(as.factor(data[[x]]))
     }
     else {
         quote(data[, x])


### PR DESCRIPTION
… dplyr package

medflex doesn't play well with `tbl_df` data.frames from the popular `dplyr` package. The pull request fixes that at least in one location. There might be problems at other places too but at least this error disappears. Probably all syntax like `data[, ONEVARIABLE]` doesn't work. `data[[VARIABLE]]` solves the problem

```
# the example from the paper works fine
impFit <- glm(UPB ~ factor(attbin) + negaff + gender + educ + age, family = binomial("logit"), data = UPBdata)
expData <- neImpute(impFit)
# when the dataset is first converted with tbl_df, neImpute doesn't work
impFit <- glm(UPB ~ factor(attbin) + negaff + gender + educ + age, family = binomial("logit"), data = tbl_df(UPBdata))
expData <- neImpute(impFit)
```
